### PR TITLE
Correção na versão do h2 correta para o flyway

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
+			<version>2.2.224</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Adicionando a versão correta do h2 para remover o aviso do flyway